### PR TITLE
Added GH Actions and Improved update_current_tag

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,42 @@
+---
+
+name: Check Repo Updates
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Check every Sunday
+
+jobs:
+  check-repo-updates:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [ ettus-uhd, free5gc, free5gc-webconsole, oai, open5gs, open5gs-dbctl, open5gs-webui, scrcpy, srsran, uearansim ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set env vars
+        run: |
+          echo "IMAGE_DIR=./images/${{ matrix.image }}" >> $GITHUB_ENV
+
+      - name: Update Current Tag
+        id: update_tag
+        run: |
+          cd ${{ env.IMAGE_DIR }}
+          [[ -f ./update_current_tag.sh ]] && \
+            ./update_current_tag.sh || \
+            exit 1
+
+      # Launch Pull Request only when the version is updated 
+      - name: Create Pull Request for ${{ matrix.image }}
+        if: steps.update_tag.outputs.OUTPUT == 0
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secret.gh_token }}
+          base: main
+          branch: ${{ matrix.image }}-dev
+          commit-message: "Updating version on ${{ matrix.image }} Image"
+          delete-branch: true
+          title: "[${{ matrix.image }}] Update Version"
+
+

--- a/images/free5gc-webconsole/update_current_tag.sh
+++ b/images/free5gc-webconsole/update_current_tag.sh
@@ -16,7 +16,7 @@ CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v
 
 # Compare CURRENT_TAG with saved IMAGE_TAG
 [[ ${CURRENT_TAG} == ${IMAGE_TAG} ]] || {
-	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${current_tag}"
+	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${CURRENT_TAG}"
 	sed -i "/IMAGE_TAG/s/=[.0-9]\+$/=${CURRENT_TAG}/" image_info.sh
 	exit 0
 } 

--- a/images/free5gc-webconsole/update_current_tag.sh
+++ b/images/free5gc-webconsole/update_current_tag.sh
@@ -1,5 +1,25 @@
 #/bin/bash
 
-current_tag=`wget -O- -q https://api.github.com/repos/free5gc/webconsole/git/refs/tags/ | jq -r '.[].ref' | cut -d '/' -f3 | cut -c2- | tail -1`
-echo "updating IMAGE_TAG to ${current_tag} in image_info.sh"
-sed -i "s/IMAGE_TAG=.*/IMAGE_TAG=${current_tag}/g" image_info.sh
+REMOTE_REPO_URL="https://api.github.com/repos/free5gc/webconsole/git/refs/tags"
+
+# Fetch the last version available on the remote repository
+CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
+# sed explanation
+# -n dont print anything
+# /v[0-9.]\+/h; every match with "v[0-9.]\+" gets stored on hold
+# $g; replace contents of pattern space with hold space, adds last match as last line to buffer
+# s//\1/; replace pattern, removes everything around version
+# $p only last line is printed
+
+# Load IMAGE_TAG
+[[ -f image_info.sh ]] && source image_info.sh || exit 1
+
+# Compare CURRENT_TAG with saved IMAGE_TAG
+[[ ${CURRENT_TAG} == ${IMAGE_TAG} ]] || {
+	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${current_tag}"
+	sed -i "/IMAGE_TAG/s/=[.0-9]\+$/=${CURRENT_TAG}/" image_info.sh
+	exit 0
+} 
+
+# Fail otherwise
+exit 1

--- a/images/free5gc-webconsole/update_current_tag.sh
+++ b/images/free5gc-webconsole/update_current_tag.sh
@@ -2,14 +2,24 @@
 
 REMOTE_REPO_URL="https://api.github.com/repos/free5gc/webconsole/git/refs/tags"
 
+GH="https://api.github.*"
+GL="https://gitlab.*"
+
 # Fetch the last version available on the remote repository
-CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
+if [[ ${REMOTE_REPO_URL} =~ ${GH} ]] ; then
+	CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
 # sed explanation
 # -n dont print anything
 # /v[0-9.]\+/h; every match with "v[0-9.]\+" gets stored on hold
 # $g; replace contents of pattern space with hold space, adds last match as last line to buffer
 # s//\1/; replace pattern, removes everything around version
 # $p only last line is printed
+elif [[ ${REMOTE_REPO_URL} =~ ${GL} ]] ; then
+	CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | jq -r '.[].name' | sed -n '1p' )
+else
+	echo "Error Reading URL"
+	exit 1
+fi
 
 # Load IMAGE_TAG
 [[ -f image_info.sh ]] && source image_info.sh || exit 1

--- a/images/free5gc/update_current_tag.sh
+++ b/images/free5gc/update_current_tag.sh
@@ -1,5 +1,26 @@
 #/bin/bash
 
-current_tag=`wget -O- -q https://api.github.com/repos/free5gc/free5gc/git/refs/tags/ | jq -r '.[].ref' | cut -d '/' -f3 | cut -c2- | tail -1`
-echo "updating IMAGE_TAG to ${current_tag} in image_info.sh"
-sed -i "s/IMAGE_TAG=.*/IMAGE_TAG=${current_tag}/g" image_info.sh
+REMOTE_REPO_URL="https://api.github.com/repos/free5gc/free5gc/git/refs/tags"
+#current_tag=$( wget -O- -q ${REMOTE_REPO_URL} | jq -r '.[].ref' | cut -d '/' -f3 | cut -c2- | tail -1 )
+
+# Fetch the last version available on the remote repository
+CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
+# sed explanation
+# -n dont print anything
+# /v[0-9.]\+/h; every match with "v[0-9.]\+" gets stored on hold
+# $g; replace contents of pattern space with hold space, adds last match as last line to buffer
+# s//\1/; replace pattern, removes everything around version
+# $p only last line is printed
+
+# Load IMAGE_TAG
+[[ -f image_info.sh ]] && source image_info.sh || exit 1
+
+# Compare CURRENT_TAG with saved IMAGE_TAG
+[[ ${CURRENT_TAG} == ${IMAGE_TAG} ]] || {
+	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${current_tag}"
+	sed -i "/IMAGE_TAG/s/=[.0-9]\+$/=${CURRENT_TAG}/" image_info.sh
+	exit 0
+} 
+
+# Fail otherwise
+exit 1

--- a/images/free5gc/update_current_tag.sh
+++ b/images/free5gc/update_current_tag.sh
@@ -1,16 +1,25 @@
 #/bin/bash
 
 REMOTE_REPO_URL="https://api.github.com/repos/free5gc/free5gc/git/refs/tags"
-#current_tag=$( wget -O- -q ${REMOTE_REPO_URL} | jq -r '.[].ref' | cut -d '/' -f3 | cut -c2- | tail -1 )
+
+GH="https://api.github.*"
+GL="https://gitlab.*"
 
 # Fetch the last version available on the remote repository
-CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
+if [[ ${REMOTE_REPO_URL} =~ ${GH} ]] ; then
+	CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
 # sed explanation
 # -n dont print anything
 # /v[0-9.]\+/h; every match with "v[0-9.]\+" gets stored on hold
 # $g; replace contents of pattern space with hold space, adds last match as last line to buffer
 # s//\1/; replace pattern, removes everything around version
 # $p only last line is printed
+elif [[ ${REMOTE_REPO_URL} =~ ${GL} ]] ; then
+	CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | jq -r '.[].name' | sed -n '1p' )
+else
+	echo "Error Reading URL"
+	exit 1
+fi
 
 # Load IMAGE_TAG
 [[ -f image_info.sh ]] && source image_info.sh || exit 1

--- a/images/free5gc/update_current_tag.sh
+++ b/images/free5gc/update_current_tag.sh
@@ -17,7 +17,7 @@ CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v
 
 # Compare CURRENT_TAG with saved IMAGE_TAG
 [[ ${CURRENT_TAG} == ${IMAGE_TAG} ]] || {
-	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${current_tag}"
+	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${CURRENT_TAG}"
 	sed -i "/IMAGE_TAG/s/=[.0-9]\+$/=${CURRENT_TAG}/" image_info.sh
 	exit 0
 } 

--- a/images/oai/update_current_tag.sh
+++ b/images/oai/update_current_tag.sh
@@ -2,14 +2,24 @@
 
 REMOTE_REPO_URL="https://gitlab.eurecom.fr/api/v4/projects/223/repository/tags"
 
+GH="https://api.github.*"
+GL="https://gitlab.*"
+
 # Fetch the last version available on the remote repository
-CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
+if [[ ${REMOTE_REPO_URL} =~ ${GH} ]] ; then
+	CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
 # sed explanation
 # -n dont print anything
 # /v[0-9.]\+/h; every match with "v[0-9.]\+" gets stored on hold
 # $g; replace contents of pattern space with hold space, adds last match as last line to buffer
 # s//\1/; replace pattern, removes everything around version
 # $p only last line is printed
+elif [[ ${REMOTE_REPO_URL} =~ ${GL} ]] ; then
+	CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | jq -r '.[].name' | sed -n '1p' )
+else
+	echo "Error Reading URL"
+	exit 1
+fi
 
 # Load IMAGE_TAG
 [[ -f image_info.sh ]] && source image_info.sh || exit 1

--- a/images/oai/update_current_tag.sh
+++ b/images/oai/update_current_tag.sh
@@ -1,5 +1,25 @@
 #/bin/bash
 
-current_tag=`wget -O- -q https://gitlab.eurecom.fr/api/v4/projects/223/repository/tags | jq -r '.[].name' | head -1`
-echo "updating IMAGE_TAG to ${current_tag} in image_info.sh"
-sed -i "s/IMAGE_TAG=.*/IMAGE_TAG=${current_tag}/g" image_info.sh
+REMOTE_REPO_URL="https://gitlab.eurecom.fr/api/v4/projects/223/repository/tags"
+
+# Fetch the last version available on the remote repository
+CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
+# sed explanation
+# -n dont print anything
+# /v[0-9.]\+/h; every match with "v[0-9.]\+" gets stored on hold
+# $g; replace contents of pattern space with hold space, adds last match as last line to buffer
+# s//\1/; replace pattern, removes everything around version
+# $p only last line is printed
+
+# Load IMAGE_TAG
+[[ -f image_info.sh ]] && source image_info.sh || exit 1
+
+# Compare CURRENT_TAG with saved IMAGE_TAG
+[[ ${CURRENT_TAG} == ${IMAGE_TAG} ]] || {
+	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${current_tag}"
+	sed -i "/IMAGE_TAG/s/=[.0-9]\+$/=${CURRENT_TAG}/" image_info.sh
+	exit 0
+} 
+
+# Fail otherwise
+exit 1

--- a/images/oai/update_current_tag.sh
+++ b/images/oai/update_current_tag.sh
@@ -16,7 +16,7 @@ CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v
 
 # Compare CURRENT_TAG with saved IMAGE_TAG
 [[ ${CURRENT_TAG} == ${IMAGE_TAG} ]] || {
-	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${current_tag}"
+	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${CURRENT_TAG}"
 	sed -i "/IMAGE_TAG/s/=[.0-9]\+$/=${CURRENT_TAG}/" image_info.sh
 	exit 0
 } 

--- a/images/open5gs-webui/update_current_tag.sh
+++ b/images/open5gs-webui/update_current_tag.sh
@@ -2,14 +2,24 @@
 
 REMOTE_REPO_URL="https://api.github.com/repos/open5gs/open5gs/git/refs/tags/"
 
+GH="https://api.github.*"
+GL="https://gitlab.*"
+
 # Fetch the last version available on the remote repository
-CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
+if [[ ${REMOTE_REPO_URL} =~ ${GH} ]] ; then
+	CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
 # sed explanation
 # -n dont print anything
 # /v[0-9.]\+/h; every match with "v[0-9.]\+" gets stored on hold
 # $g; replace contents of pattern space with hold space, adds last match as last line to buffer
 # s//\1/; replace pattern, removes everything around version
 # $p only last line is printed
+elif [[ ${REMOTE_REPO_URL} =~ ${GL} ]] ; then
+	CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | jq -r '.[].name' | sed -n '1p' )
+else
+	echo "Error Reading URL"
+	exit 1
+fi
 
 # Load IMAGE_TAG
 [[ -f image_info.sh ]] && source image_info.sh || exit 1

--- a/images/open5gs-webui/update_current_tag.sh
+++ b/images/open5gs-webui/update_current_tag.sh
@@ -16,7 +16,7 @@ CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v
 
 # Compare CURRENT_TAG with saved IMAGE_TAG
 [[ ${CURRENT_TAG} == ${IMAGE_TAG} ]] || {
-	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${current_tag}"
+	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${CURRENT_TAG}"
 	sed -i "/IMAGE_TAG/s/=[.0-9]\+$/=${CURRENT_TAG}/" image_info.sh
 	exit 0
 } 

--- a/images/open5gs-webui/update_current_tag.sh
+++ b/images/open5gs-webui/update_current_tag.sh
@@ -1,5 +1,25 @@
 #/bin/bash
 
-current_tag=`wget -O- -q https://api.github.com/repos/open5gs/open5gs/git/refs/tags/ | jq -r '.[].ref' | cut -d '/' -f3 | cut -c2- | tail -1`
-echo "updating IMAGE_TAG to ${current_tag} in image_info.sh"
-sed -i "s/IMAGE_TAG=.*/IMAGE_TAG=${current_tag}/g" image_info.sh
+REMOTE_REPO_URL="https://api.github.com/repos/open5gs/open5gs/git/refs/tags/"
+
+# Fetch the last version available on the remote repository
+CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
+# sed explanation
+# -n dont print anything
+# /v[0-9.]\+/h; every match with "v[0-9.]\+" gets stored on hold
+# $g; replace contents of pattern space with hold space, adds last match as last line to buffer
+# s//\1/; replace pattern, removes everything around version
+# $p only last line is printed
+
+# Load IMAGE_TAG
+[[ -f image_info.sh ]] && source image_info.sh || exit 1
+
+# Compare CURRENT_TAG with saved IMAGE_TAG
+[[ ${CURRENT_TAG} == ${IMAGE_TAG} ]] || {
+	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${current_tag}"
+	sed -i "/IMAGE_TAG/s/=[.0-9]\+$/=${CURRENT_TAG}/" image_info.sh
+	exit 0
+} 
+
+# Fail otherwise
+exit 1

--- a/images/open5gs/update_current_tag.sh
+++ b/images/open5gs/update_current_tag.sh
@@ -2,14 +2,24 @@
 
 REMOTE_REPO_URL="https://api.github.com/repos/open5gs/open5gs/git/refs/tags/"
 
+GH="https://api.github.*"
+GL="https://gitlab.*"
+
 # Fetch the last version available on the remote repository
-CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
+if [[ ${REMOTE_REPO_URL} =~ ${GH} ]] ; then
+	CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
 # sed explanation
 # -n dont print anything
 # /v[0-9.]\+/h; every match with "v[0-9.]\+" gets stored on hold
 # $g; replace contents of pattern space with hold space, adds last match as last line to buffer
 # s//\1/; replace pattern, removes everything around version
 # $p only last line is printed
+elif [[ ${REMOTE_REPO_URL} =~ ${GL} ]] ; then
+	CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | jq -r '.[].name' | sed -n '1p' )
+else
+	echo "Error Reading URL"
+	exit 1
+fi
 
 # Load IMAGE_TAG
 [[ -f image_info.sh ]] && source image_info.sh || exit 1

--- a/images/open5gs/update_current_tag.sh
+++ b/images/open5gs/update_current_tag.sh
@@ -16,7 +16,7 @@ CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v
 
 # Compare CURRENT_TAG with saved IMAGE_TAG
 [[ ${CURRENT_TAG} == ${IMAGE_TAG} ]] || {
-	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${current_tag}"
+	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${CURRENT_TAG}"
 	sed -i "/IMAGE_TAG/s/=[.0-9]\+$/=${CURRENT_TAG}/" image_info.sh
 	exit 0
 } 

--- a/images/open5gs/update_current_tag.sh
+++ b/images/open5gs/update_current_tag.sh
@@ -1,5 +1,25 @@
 #/bin/bash
 
-current_tag=`wget -O- -q https://api.github.com/repos/open5gs/open5gs/git/refs/tags/ | jq -r '.[].ref' | cut -d '/' -f3 | cut -c2- | tail -1`
-echo "updating IMAGE_TAG to ${current_tag} in image_info.sh"
-sed -i "s/IMAGE_TAG=.*/IMAGE_TAG=${current_tag}/g" image_info.sh
+REMOTE_REPO_URL="https://api.github.com/repos/open5gs/open5gs/git/refs/tags/"
+
+# Fetch the last version available on the remote repository
+CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
+# sed explanation
+# -n dont print anything
+# /v[0-9.]\+/h; every match with "v[0-9.]\+" gets stored on hold
+# $g; replace contents of pattern space with hold space, adds last match as last line to buffer
+# s//\1/; replace pattern, removes everything around version
+# $p only last line is printed
+
+# Load IMAGE_TAG
+[[ -f image_info.sh ]] && source image_info.sh || exit 1
+
+# Compare CURRENT_TAG with saved IMAGE_TAG
+[[ ${CURRENT_TAG} == ${IMAGE_TAG} ]] || {
+	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${current_tag}"
+	sed -i "/IMAGE_TAG/s/=[.0-9]\+$/=${CURRENT_TAG}/" image_info.sh
+	exit 0
+} 
+
+# Fail otherwise
+exit 1

--- a/images/srsran/update_current_tag.sh
+++ b/images/srsran/update_current_tag.sh
@@ -16,7 +16,7 @@ CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v
 
 # Compare CURRENT_TAG with saved IMAGE_TAG
 [[ ${CURRENT_TAG} == ${IMAGE_TAG} ]] || {
-	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${current_tag}"
+	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${CURRENT_TAG}"
 	sed -i "/IMAGE_TAG/s/=[.0-9]\+$/=${CURRENT_TAG}/" image_info.sh
 	exit 0
 } 

--- a/images/srsran/update_current_tag.sh
+++ b/images/srsran/update_current_tag.sh
@@ -1,5 +1,25 @@
 #/bin/bash
 
-current_tag=`wget -O- -q https://api.github.com/repos/srsran/srsRAN/git/refs/tags/ | jq -r '.[].ref' | grep release | cut -d '/' -f3 | cut -c9- | tail -1`
-echo "updating IMAGE_TAG to ${current_tag} in image_info.sh"
-sed -i "s/IMAGE_TAG=.*/IMAGE_TAG=${current_tag}/g" image_info.sh
+REMOTE_REPO_URL="https://api.github.com/repos/srsran/srsRAN/git/refs/tags/"
+
+# Fetch the last version available on the remote repository
+CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
+# sed explanation
+# -n dont print anything
+# /v[0-9.]\+/h; every match with "v[0-9.]\+" gets stored on hold
+# $g; replace contents of pattern space with hold space, adds last match as last line to buffer
+# s//\1/; replace pattern, removes everything around version
+# $p only last line is printed
+
+# Load IMAGE_TAG
+[[ -f image_info.sh ]] && source image_info.sh || exit 1
+
+# Compare CURRENT_TAG with saved IMAGE_TAG
+[[ ${CURRENT_TAG} == ${IMAGE_TAG} ]] || {
+	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${current_tag}"
+	sed -i "/IMAGE_TAG/s/=[.0-9]\+$/=${CURRENT_TAG}/" image_info.sh
+	exit 0
+} 
+
+# Fail otherwise
+exit 1

--- a/images/srsran/update_current_tag.sh
+++ b/images/srsran/update_current_tag.sh
@@ -2,14 +2,24 @@
 
 REMOTE_REPO_URL="https://api.github.com/repos/srsran/srsRAN/git/refs/tags/"
 
+GH="https://api.github.*"
+GL="https://gitlab.*"
+
 # Fetch the last version available on the remote repository
-CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
+if [[ ${REMOTE_REPO_URL} =~ ${GH} ]] ; then
+	CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
 # sed explanation
 # -n dont print anything
 # /v[0-9.]\+/h; every match with "v[0-9.]\+" gets stored on hold
 # $g; replace contents of pattern space with hold space, adds last match as last line to buffer
 # s//\1/; replace pattern, removes everything around version
 # $p only last line is printed
+elif [[ ${REMOTE_REPO_URL} =~ ${GL} ]] ; then
+	CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | jq -r '.[].name' | sed -n '1p' )
+else
+	echo "Error Reading URL"
+	exit 1
+fi
 
 # Load IMAGE_TAG
 [[ -f image_info.sh ]] && source image_info.sh || exit 1

--- a/images/ueransim/update_current_tag.sh
+++ b/images/ueransim/update_current_tag.sh
@@ -2,14 +2,24 @@
 
 REMOTE_REPO_URL="https://api.github.com/repos/aligungr/UERANSIM/git/refs/tags/"
 
+GH="https://api.github.*"
+GL="https://gitlab.*"
+
 # Fetch the last version available on the remote repository
-CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
+if [[ ${REMOTE_REPO_URL} =~ ${GH} ]] ; then
+	CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
 # sed explanation
 # -n dont print anything
 # /v[0-9.]\+/h; every match with "v[0-9.]\+" gets stored on hold
 # $g; replace contents of pattern space with hold space, adds last match as last line to buffer
 # s//\1/; replace pattern, removes everything around version
 # $p only last line is printed
+elif [[ ${REMOTE_REPO_URL} =~ ${GL} ]] ; then
+	CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | jq -r '.[].name' | sed -n '1p' )
+else
+	echo "Error Reading URL"
+	exit 1
+fi
 
 # Load IMAGE_TAG
 [[ -f image_info.sh ]] && source image_info.sh || exit 1

--- a/images/ueransim/update_current_tag.sh
+++ b/images/ueransim/update_current_tag.sh
@@ -16,7 +16,7 @@ CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v
 
 # Compare CURRENT_TAG with saved IMAGE_TAG
 [[ ${CURRENT_TAG} == ${IMAGE_TAG} ]] || {
-	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${current_tag}"
+	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${CURRENT_TAG}"
 	sed -i "/IMAGE_TAG/s/=[.0-9]\+$/=${CURRENT_TAG}/" image_info.sh
 	exit 0
 } 

--- a/images/ueransim/update_current_tag.sh
+++ b/images/ueransim/update_current_tag.sh
@@ -1,5 +1,25 @@
 #/bin/bash
 
-current_tag=`wget -O- -q https://api.github.com/repos/aligungr/UERANSIM/git/refs/tags/ | jq -r '.[].ref' | cut -d '/' -f3 | cut -c2- | tail -1`
-echo "updating IMAGE_TAG to ${current_tag} in image_info.sh"
-sed -i "s/IMAGE_TAG=.*/IMAGE_TAG=${current_tag}/g" image_info.sh
+REMOTE_REPO_URL="https://api.github.com/repos/aligungr/UERANSIM/git/refs/tags/"
+
+# Fetch the last version available on the remote repository
+CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | sed -n '/v[0-9.]\+/h; $g; s/^.*\/v\([0-9.]\+\).*$/\1/; $p' )
+# sed explanation
+# -n dont print anything
+# /v[0-9.]\+/h; every match with "v[0-9.]\+" gets stored on hold
+# $g; replace contents of pattern space with hold space, adds last match as last line to buffer
+# s//\1/; replace pattern, removes everything around version
+# $p only last line is printed
+
+# Load IMAGE_TAG
+[[ -f image_info.sh ]] && source image_info.sh || exit 1
+
+# Compare CURRENT_TAG with saved IMAGE_TAG
+[[ ${CURRENT_TAG} == ${IMAGE_TAG} ]] || {
+	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${current_tag}"
+	sed -i "/IMAGE_TAG/s/=[.0-9]\+$/=${CURRENT_TAG}/" image_info.sh
+	exit 0
+} 
+
+# Fail otherwise
+exit 1


### PR DESCRIPTION
Se añade un nuevo workflow a GH Actions tipo schedule encargado de comprobar si existe una imagen más reciente que la actual para cada una de las imagenes indicadas.
Genera un PR para cada imagen actualizada.

>>> TAREA PENDIENTE: Crear un secret en el repo o en el dominio que contenga un token con los permisos correspondientes para poder realizar el PR


Se modifican los scripts encargados de actualizar la versión más reciente de cada imagen.

Se separa la URL de consulta en una nueva variable,  gestión de errores y valor de retorno según el resultado del script.
Actualizado -> OK
No Actualizado -> NO OK